### PR TITLE
Add a /api/symbols endpoint

### DIFF
--- a/api/chains.go
+++ b/api/chains.go
@@ -5,17 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strconv"
 
-	"github.com/haideralsh/oc/utils"
+	oc "github.com/haideralsh/oc/utils"
 )
-
-type Symbol = string
-
-const baseUrl = "https://sandbox.tradier.com/v1/markets"
-
-var token = os.Getenv("TRADIER_TOKEN")
 
 type OptionChain struct {
 	Percentage float64 `json:"percentage"`
@@ -25,8 +18,8 @@ type OptionChain struct {
 }
 
 type RequestBody struct {
-	Symbols    []Symbol `json:"symbols"`
-	Percentage float64  `json:"percentage"`
+	Symbols    []oc.Symbol `json:"symbols"`
+	Percentage float64     `json:"percentage"`
 }
 
 func Chains(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +31,7 @@ func Chains(w http.ResponseWriter, r *http.Request) {
 	symbols := parsedRequest.Symbols
 	percentage := parsedRequest.Percentage / 100.00
 
-	res, err := Find(symbols, percentage)
+	res, err := find(symbols, percentage)
 
 	if err != nil {
 		log.Print(err)
@@ -46,12 +39,12 @@ func Chains(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	utils.SetCorsHeaders(w)
+	oc.SetCorsHeaders(w)
 
 	w.Write(res)
 }
 
-func Find(symbols []string, percentage float64) ([]byte, error) {
+func find(symbols []string, percentage float64) ([]byte, error) {
 	coefficient := 1.00 + percentage
 
 	quotes := make(map[string]<-chan float64)
@@ -108,9 +101,9 @@ func getOptions(symbol, expiration string) <-chan []interface{} {
 	go func() {
 		defer close(r)
 
-		endpoint := fmt.Sprintf("%s/options/chains?symbol=%s&expiration=%s&greeks=false", baseUrl, symbol, expiration)
-		req := utils.BuildRequest(endpoint, token)
-		res := utils.GetResponse(req)
+		endpoint := fmt.Sprintf("%s/options/chains?symbol=%s&expiration=%s&greeks=false", oc.BaseUrl, symbol, expiration)
+		req := oc.BuildRequest(endpoint, oc.Token)
+		res := oc.GetResponse(req)
 
 		var data map[string]interface{}
 		err := json.Unmarshal(res, &data)
@@ -157,9 +150,9 @@ func getQuote(symbol string) <-chan float64 {
 	go func() {
 		defer close(r)
 
-		endpoint := fmt.Sprintf("%s/quotes?symbols=%s&greeks=false", baseUrl, symbol)
-		req := utils.BuildRequest(endpoint, token)
-		res := utils.GetResponse(req)
+		endpoint := fmt.Sprintf("%s/quotes?symbols=%s&greeks=false", oc.BaseUrl, symbol)
+		req := oc.BuildRequest(endpoint, oc.Token)
+		res := oc.GetResponse(req)
 
 		var data map[string]interface{}
 		err := json.Unmarshal(res, &data)
@@ -189,9 +182,9 @@ func getOptionExpirations(symbol string) <-chan []interface{} {
 	go func() {
 		defer close(r)
 
-		endpoint := fmt.Sprintf("%s//options/expirations?symbol=%s&includeAllRoots=true&strikes=false", baseUrl, symbol)
-		req := utils.BuildRequest(endpoint, token)
-		res := utils.GetResponse(req)
+		endpoint := fmt.Sprintf("%s//options/expirations?symbol=%s&includeAllRoots=true&strikes=false", oc.BaseUrl, symbol)
+		req := oc.BuildRequest(endpoint, oc.Token)
+		res := oc.GetResponse(req)
 
 		var data map[string]interface{}
 		err := json.Unmarshal(res, &data)

--- a/api/chains.go
+++ b/api/chains.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 	Percentage float64  `json:"percentage"`
 }
 
-func Handler(w http.ResponseWriter, r *http.Request) {
+func Chains(w http.ResponseWriter, r *http.Request) {
 	parsedRequest, err := parseRequest(r)
 	if err != nil {
 		fmt.Fprint(w, err)

--- a/api/symbols.go
+++ b/api/symbols.go
@@ -1,0 +1,14 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/haideralsh/oc/utils"
+)
+
+func Symbols(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	utils.SetCorsHeaders(w)
+
+	w.Write([]byte("Hello from the symbols ma man"))
+}

--- a/api/symbols.go
+++ b/api/symbols.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Symbols(w http.ResponseWriter, r *http.Request) {
-	q, err := parseUrl(r.URL)
+	q, err := getQueryString(r.URL, "q")
 	if err != nil {
 		log.Print(err)
 		fmt.Fprint(w, err)
@@ -26,11 +26,11 @@ func Symbols(w http.ResponseWriter, r *http.Request) {
 	w.Write(res)
 }
 
-func parseUrl(rawUrl *url.URL) (string, error) {
+func getQueryString(rawUrl *url.URL, query string) (string, error) {
 	q, err := url.ParseQuery(rawUrl.RawQuery)
 	if err != nil {
 		return "", err
 	}
 
-	return q.Get("symbol"), nil
+	return q.Get(query), nil
 }

--- a/api/symbols.go
+++ b/api/symbols.go
@@ -1,14 +1,36 @@
 package handler
 
 import (
+	"fmt"
+	"log"
 	"net/http"
+	"net/url"
 
-	"github.com/haideralsh/oc/utils"
+	oc "github.com/haideralsh/oc/utils"
 )
 
 func Symbols(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	utils.SetCorsHeaders(w)
+	q, err := parseUrl(r.URL)
+	if err != nil {
+		log.Print(err)
+		fmt.Fprint(w, err)
+	}
 
-	w.Write([]byte("Hello from the symbols ma man"))
+	endpoint := fmt.Sprintf("%s/lookup?q=%s", oc.BaseUrl, q)
+	req := oc.BuildRequest(endpoint, oc.Token)
+	res := oc.GetResponse(req)
+
+	w.Header().Set("Content-Type", "application/json")
+	oc.SetCorsHeaders(w)
+
+	w.Write(res)
+}
+
+func parseUrl(rawUrl *url.URL) (string, error) {
+	q, err := url.ParseQuery(rawUrl.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	return q.Get("symbol"), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,8 +6,15 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 )
+
+type Symbol = string
+
+const BaseUrl = "https://sandbox.tradier.com/v1/markets"
+
+var Token = os.Getenv("TRADIER_TOKEN")
 
 func SetCorsHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Headers", "*")


### PR DESCRIPTION
Adds a `/api/symbols?q=` endpoint to lookup symbols names. This endpoint will be used to fill the autocomplete menu on the frontend. 